### PR TITLE
Add simple Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.4-onbuild
+
+EXPOSE 8080
+CMD ["app", "-host", "0.0.0.0", "-port", "8080"]


### PR DESCRIPTION
Just sharing a Dockerfile that is working for us, using the Docker "trusted build" golang image. Usage:

```
# Build the image
$ docker build -t rrda .

# Run with the default settings, exposing 8080 on the host
$ docker run -p 8080:8080 -d rrda

# Test it
$ curl http://localhost:8080/8.8.8.8:53/example.org/ns
```