### PR TITLE
Add a -timeout parameter to dictate how long (in ms) we are willing to wait for an answer to our DNS queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ By default, RRDA will bind on localhost, port 8080, in HTTP mode.
 	        Set the server host (default "127.0.0.1")
 	  -port string
 	        Set the server port (default "8080")
+	  -timeout int
+	        Set the query timeout in ms (default 2000)
 	  -version
 	        Display version
 

--- a/rrda.go
+++ b/rrda.go
@@ -27,7 +27,10 @@ import (
 	"net/http/fcgi"
 	"os"
 	"strings"
+	"time"
 )
+
+var timeout_ms int
 
 type Error struct {
 	Code    int    `json:"code"`
@@ -107,6 +110,9 @@ func resolve(w http.ResponseWriter, r *http.Request, server string, domain strin
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	c := new(dns.Client)
+	c.Dialer = &net.Dialer{
+		Timeout: time.Duration(timeout_ms) * time.Millisecond,
+	}
 
 Redo:
 	if in, _, err := c.Exchange(m, server); err == nil { // Second return value is RTT, not used for now
@@ -167,6 +173,7 @@ func main() {
 	fastcgi := flag.Bool("fastcgi", false, "Enable FastCGI mode")
 	host := flag.String("host", "127.0.0.1", "Set the server host")
 	port := flag.String("port", "8080", "Set the server port")
+	flag.IntVar(&timeout_ms, "timeout", 2000, "Set the query timeout in ms")
 	version := flag.Bool("version", false, "Display version")
 
 	mode := "HTTP"


### PR DESCRIPTION
In more time-sensitive scenarios where one may want to fail and move on quickly if an answer to a DNS query cannot be returned in a timely fashion, it may be beneficial to have the ability to set a timeout value that is lower than the system's default.

This takes advantage of [miekg/dns](https://github.com/miekg/dns)'s ability to specify a `Timeout` parameter through a `net.Dialer` as explained in their documentation:
```
More advanced options are available using a net.Dialer and the corresponding API.
For example it is possible to set a timeout, or to specify a source IP address
and port to use for the connection:
	c := new(dns.Client)
	laddr := net.UDPAddr{
		IP: net.ParseIP("[::1]"),
		Port: 12345,
		Zone: "",
	}
	c.Dialer := &net.Dialer{
		Timeout: 200 * time.Millisecond,
		LocalAddr: &laddr,
	}
	in, rtt, err := c.Exchange(m1, "8.8.8.8:53")
```
Before the change:
```
# ./rrda -host=127.0.0.1 -port=5353
# time curl http://127.0.0.1:5353/:53/<domain>/<query type>
{"code":501,"message":"DNS server could not be reached"}

real    0m2.011s
user    0m0.003s
sys     0m0.007s
```
After the change:
```
# ./rrda -host=127.0.0.1 -port=5353 -timeout=200
# time curl http://127.0.0.1:5353/:53/<domain>/<query type>
{"code":501,"message":"DNS server could not be reached"}

real    0m0.212s
user    0m0.002s
sys     0m0.008s
```